### PR TITLE
Update from 1.0.0.beta1 to 1.0.0.beta2 to fix cli error

### DIFF
--- a/lib/mina/npm/version.rb
+++ b/lib/mina/npm/version.rb
@@ -1,5 +1,5 @@
 module Mina
   module Npm
-    VERSION = '1.0.0.beta1'
+    VERSION = '1.0.0.beta2'
   end
 end

--- a/mina-npm.gemspec
+++ b/mina-npm.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_dependency 'mina', '1.0.0.beta1'
+  spec.add_dependency 'mina', '1.0.0.beta2'
 end


### PR DESCRIPTION
Update dependency mina from version 1.0.0.beta1 to 1.0.0.beta2 to fix CLI error. Detail in:
https://github.com/mina-deploy/mina/issues/405#issuecomment-237609810
